### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ app/console my:command
 
 ## Write commands
 
-Your commands should extend `Ivoba\Command\Command` to have access to the 2 useful following commands:
+Your commands should extend `Ivoba\Silex\Command\Command` to have access to the 2 useful following commands:
 
 * `getSilexApplication`, which returns the silex application
 * `getProjectDirectory`, which returns your project's root directory (as configured earlier)


### PR DESCRIPTION
Fix for extends classname for commands

The correct classname is Ivoba\Silex\Command\Command, so without 'Silex' don't work and is a little confusing :)
